### PR TITLE
Server Port and Gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+client/node_modules/
+server/node_modules/

--- a/server/server.js
+++ b/server/server.js
@@ -1,4 +1,4 @@
-const PORT = 8000
+const PORT = process.env.PORT ?? 8000;
 const express = require('express')
 const cors = require('cors')
 const app = express()


### PR DESCRIPTION
The `.gitignore` isn't required, but it always makes things easier.

The problem was related to the Port. By default, our servers (and from what I know, we're not the only ones) are using the `PORT` env variable (we're setting it in the background). This means that server.js should use `process.ENV.PORT` instead of a set port.